### PR TITLE
Return rendered template when no output is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Ruby templating using YAML datasources
   content = YAML.load(File.read("file.yml"))
   r = Ruyml::Data.new(content)
   r.render("template.erb", "output.txt")
+  
+  result = r.render("template.erb") # result containts the rendered template as string
 ```
 
 ## CLI

--- a/lib/ruyml.rb
+++ b/lib/ruyml.rb
@@ -21,7 +21,7 @@ module Ruyml
 
     # Renders RUYML data using the given template.
     # Rendered data is either written to an optional
-    # output file path or to stdout.
+    # output file path  if provided or as return value.
     def render(template, output = nil)
       result = ERB.new(File.read(template), 0, '-').result(binding)
       if !output.nil?
@@ -30,6 +30,7 @@ module Ruyml
         end
       else
         puts result
+        result
       end
     end
 

--- a/lib/ruyml/version.rb
+++ b/lib/ruyml/version.rb
@@ -1,3 +1,3 @@
 module Ruyml
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Hi,

this is an addon to my recently opened issue. When no output is provided for the render method the output is not only logged to console but also returned by the function. That way one can process this output and do even more with that. I also bumped the version to 0.2.0 sticking to semantic versioning and updated the readme. Glad to hear from you.

Best regards 
dasheck